### PR TITLE
feat: Infection Mutation Testing Framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,4 @@ install:
 	@sudo ln -sf $(shell pwd)/bin/phpctl        /usr/local/bin/phpctl
 	@sudo ln -sf $(shell pwd)/bin/phpstan       /usr/local/bin/phpstan
 	@sudo ln -sf $(shell pwd)/bin/phpunit       /usr/local/bin/phpunit
+	@sudo ln -sf $(shell pwd)/bin/infection     /usr/local/bin/infection

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ phpctl sh echo 'Hello, World!' # To run arbitrary sh commands inside the contain
 | `repl`          | Starts a PHP REPL session (powered by [PsySH](https://psysh.org/)). |
 | `php-cs-fixer`  | Runs PHP-CS-Fixer.                                                  |
 | `phpstan`       | Runs PHPStan.                                                       |
+| `infection`     | Runs [Infection](https://infection.github.io/).                     |
 
 ### Scaffolders
 | Command                    | Description                                                   |
@@ -71,6 +72,7 @@ phpctl sh echo 'Hello, World!' # To run arbitrary sh commands inside the contain
 - `phpunit`
 - `php-cs-fixer`
 - `phpstan`
+- `infection`
 
 ### Helpers
 | Command                      | Description                                                  |

--- a/bin/infection
+++ b/bin/infection
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+phpctl infection $@

--- a/installer.sh
+++ b/installer.sh
@@ -9,6 +9,7 @@ symlink() {
     sudo ln -sf "${INSTALL_DIR}/bin/phpctl"       /usr/local/bin/pctl
     sudo ln -sf "${INSTALL_DIR}/bin/phpctl"       /usr/local/bin/phpctl
     sudo ln -sf "${INSTALL_DIR}/bin/phpstan"      /usr/local/bin/phpstan
+    sudo ln -sf "${INSTALL_DIR}/bin/infection"    /usr/local/bin/infection
     sudo ln -sf "${INSTALL_DIR}/bin/phpunit"      /usr/local/bin/phpunit
 }
 
@@ -33,5 +34,6 @@ else
     echo "  sudo ln -sf ${INSTALL_DIR}/bin/phpunit      /usr/local/bin/phpunit"
     echo "  sudo ln -sf ${INSTALL_DIR}/bin/php-cs-fixer /usr/local/bin/php-cs-fixer"
     echo "  sudo ln -sf ${INSTALL_DIR}/bin/phpstan      /usr/local/bin/phpstan"
+    echo "  sudo ln -sf ${INSTALL_DIR}/bin/infection    /usr/local/bin/infection"
     echo ""
 fi

--- a/skeletons/infection.json5
+++ b/skeletons/infection.json5
@@ -1,0 +1,13 @@
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "timeout": 10,
+    "logs": {
+        "text": "infection.log"
+    },
+    "mutators": {},
+    "testFramework": "phpunit",
+    "bootstrap": "vendor/autoload.php",
+    "minMsi": 0
+}

--- a/src/help.sh
+++ b/src/help.sh
@@ -27,6 +27,7 @@ help() {
     echo -e "\033[0;32m  repl                       \033[0m Starts a PHP REPL session (powered by PsySH)"
     echo -e "\033[0;32m  php-cs-fixer               \033[0m Runs PHP-CS-Fixer"
     echo -e "\033[0;32m  phpstan                    \033[0m Runs PHPStan"
+    echo -e "\033[0;32m  infection                  \033[0m Runs Infection, a PHP Mutation Testing Framework"
     echo -e "\033[0;32m  create [framework] [dir]   \033[0m Creates a new project using the given framework (or package)"
     echo -e "\033[0;32m  init [skeleton]            \033[0m Initializes a skeleton configuration (phpunit, php-cs-fixer)"
     echo -e "\033[0;32m  help or man                \033[0m Displays this help message"

--- a/src/php.sh
+++ b/src/php.sh
@@ -47,3 +47,12 @@ phpstan() {
 
     run -- vendor/bin/phpstan ${@}
 }
+
+infection() {
+    if [ ! -f vendor/bin/infection ]; then
+        echo "Infection not found. Installing..."
+        run -- composer require --dev infection/infection
+    fi;
+
+    run -- vendor/bin/infection ${@}
+}

--- a/src/scaffold.sh
+++ b/src/scaffold.sh
@@ -30,6 +30,9 @@ init() {
         "phpstan")
                     skeleton="phpstan.neon"
                     ;;
+        "infection")
+            skeleton="infection.json5"
+            ;;
         *)
             echo -e "\033[0;31mSkeleton ($skeleton_alias) not handled.\033[0m"
             exit 1


### PR DESCRIPTION
# Screenshots

To ensure `phpctl infection` execution, I ran it in a PHP skeleton project in my local environment with the following folder/file configuration:

```
├── src
│   └── Infection.php
└── test
    └── InfectionTest.php
├── composer.json
├── composer.lock
├── infection.json5 (generated by `phpctl init infection`)
├── phpunit.xml
```

![infection](https://github.com/opencodeco/phpctl/assets/12822075/7a2cb510-dec2-4c1f-afd6-4810d896a122)
