### PR TITLE
Check if the ~/.phpctl directory exists before removing it

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -13,7 +13,9 @@ symlink() {
 }
 
 echo "\033[0;33mInstalling phpctl at \033[0m$INSTALL_DIR"
-rm -rf $INSTALL_DIR
+if [ -d "$INSTALL_DIR" ]; then
+    rm -ri $INSTALL_DIR
+fi
 git clone --quiet https://github.com/opencodeco/phpctl.git $INSTALL_DIR
 
 echo "Sudo will be prompted to symlink the phpctl files. \033[0;32mDo you want to continue? (y/n)\033[0m"


### PR DESCRIPTION
There is a possibility that the user already has a `.phpctl` directory in the home folder, and although the risk is low, it is not zero.

This pull request changes the behavior to check if the folder exists. If it does, then it asks the user for confirmation before deleting it.