### PR TITLE
feat(ext): SQLite3 extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --update --no-cache \
         php${PHP}-phar \
         php${PHP}-posix \
         php${PHP}-simplexml \
+        php${PHP}-sqlite3 \
         php${PHP}-tokenizer \
         php${PHP}-xml \
         php${PHP}-xmlreader \


### PR DESCRIPTION
Adding `sqlite3` extension so we can use [PHP SQLite3 interfacing](https://www.php.net/manual/en/class.sqlite3.php).

Having SQLite3 available, we can integrate a database into the application more easily just doing `new \SQLite3(':memory:');` :100:

I validated the changes in my local environment for both 82 and 83 PHP versions and everything works!