### PR TITLE
Fix: Pulling Docker Image on "Apple Silicon + Colima" Environment 

### DIFF
--- a/src/docker.sh
+++ b/src/docker.sh
@@ -31,7 +31,7 @@ run() {
         --name "phpctl_$(openssl rand -hex 6)" \
         $(env | awk -F= '/^[[:alpha:]]/{print $1}' | sed 's/^/-e/') \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        -v ~/.gitconfig:/root/.gitconfig \
+        -v ~/.gitconfig:/root/.gitconfig:ro \
         -v "$(pwd)":/usr/local/src -w /usr/local/src \
         --net host --entrypoint sh \
         ${args[@]} "$1" "$PHPCTL_IMAGE" -c "${*:2}"

--- a/src/docker.sh
+++ b/src/docker.sh
@@ -26,6 +26,7 @@ run() {
     # shellcheck disable=SC2046
     # shellcheck disable=SC2154
     $PHPCTL_RUNTIME run \
+        --platform linux/x86_64 \
         --rm "$PHPCTL_TTY" \
         --name "phpctl_$(openssl rand -hex 6)" \
         $(env | awk -F= '/^[[:alpha:]]/{print $1}' | sed 's/^/-e/') \


### PR DESCRIPTION
#### Reproducing the Error
 
 1) Try run a commands on a Apple Silicon Chip like:
 `phpctl create slim/slim /tmp/myapp`

2) Your received a message like:
![Captura de Tela 2024-01-03 às 11 51 38](https://github.com/opencodeco/phpctl/assets/1322832/313cd7ab-6a04-4671-9c4c-3fd2583f6f1f)


#### Fix
The initial solution is force the image plataform to `linux x86_64`

- [x] I validated the changes in my local environment MAC M1 + Colima.
- [x] I validated the changes in my local environment AMD LInux Mint + Docker.


