### PR TITLE
refactor(run): Output only if in verbose mode

### DIFF
--- a/src/docker.sh
+++ b/src/docker.sh
@@ -23,7 +23,9 @@ images() {
 }
 
 run() {
-    echo -e "Running \033[0;32m$PHPCTL_IMAGE\033[0m"
+    if [ -n "$PHPCTL_VERBOSE" ]; then
+        echo -e "Running \033[0;32m$PHPCTL_IMAGE\033[0m"
+    fi
 
     local phpctl_ini=""
     if [ -s phpctl.ini ]; then


### PR DESCRIPTION
This PR prevents the `Running image/name` output to fuzzy the PHP output.

<img width="682" alt="Screenshot 2024-02-02 at 17 14 29" src="https://github.com/opencodeco/phpctl/assets/183722/8c649c0f-2ebd-4831-aa85-6d8889065e75">

Previously an important output would be messed:
<img width="682" alt="Screenshot 2024-02-02 at 17 17 27" src="https://github.com/opencodeco/phpctl/assets/183722/ed0b4c6d-ae51-4dd5-a92b-5cd7be1b24fc">

Closes #9 