### PR TITLE
fix: Disable TTY in Git hook environments

### DIFF
--- a/src/docker.sh
+++ b/src/docker.sh
@@ -38,6 +38,11 @@ run() {
         composer_home="-v $composer_home:$composer_home"
     fi
 
+    if [ -n "$GIT_EXEC_PATH" ]; then
+        # In a Git hook environment, we need to disable TTY allocation
+        PHPCTL_TTY="--label=no-tty"
+    fi
+
     # shellcheck disable=SC2046
     # shellcheck disable=SC2068
     # shellcheck disable=SC2086


### PR DESCRIPTION
Disable TTY allocation when it is detected that it is running in a Git hook environment.
Closes #11 

![image](https://github.com/opencodeco/phpctl/assets/183722/e3769124-e0e4-40e7-ab5b-c50b44da4c87)