### PR TITLE
add some missing -e option for echo in installer for colorize

### DIFF
--- a/docs/phpctl-installer.sh
+++ b/docs/phpctl-installer.sh
@@ -9,7 +9,7 @@ else
     SYMLINK_DIR=$1
 fi
 
-echo "\033[0;33mInstalling phpctl at \033[0m$INSTALL_DIR"
+echo -e "\033[0;33mInstalling phpctl at \033[0m$INSTALL_DIR"
 if [ -d "$INSTALL_DIR" ]; then
     echo "The install directory is not empty. Attempting to remove it..."
     rm -rI $INSTALL_DIR
@@ -24,19 +24,20 @@ while kill -0 $PID 2> /dev/null; do
         sleep 0.1
     done
 done
+printf "\r"
 
-echo "\b "
+
 if [ -z "$1" ]; then
     echo -n "Sudo will be prompted to symlink the phpctl files."
 else
     echo -n "Files will be symlinked to ${SYMLINK_DIR}."
 fi
-echo -n " \033[0;32mDo you want to continue? (y/n)\033[0m "
+echo -e -n " \033[0;32mDo you want to continue? (y/n)\033[0m "
 read -r answer
 if [ "$answer" != "${answer#[Yy]}" ]; then
     $SUDO ${INSTALL_DIR}/scripts/symlink-bins.sh ${INSTALL_DIR}
 else
-    echo "\033[0;31mTo use phpctl globally, link the cloned script to your bin directory, like:\033[0m"
+    echo -e "\033[0;31mTo use phpctl globally, link the cloned script to your bin directory, like:\033[0m"
     echo ""
     for file in "${INSTALL_DIR}"/bin/*; do
         bin=$(basename "$file")


### PR DESCRIPTION
I try default intaller script and get a bunch of raw colors markup
![Screen Shot 2024-02-07 at 12 14 56](https://github.com/opencodeco/phpctl/assets/3378304/47e0acc0-a288-47b2-9843-c5bfb98a7b51)
and the most annoying are that `\\b`

made some changes and final result is
![Screen Shot 2024-02-07 at 12 15 40](https://github.com/opencodeco/phpctl/assets/3378304/a246b555-9aec-49b0-8386-4e243a3c3571)
no more`\\b`
