### PR TITLE
feat: add decimal extension in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --update --no-cache \
         docker-cli \
         php${PHP}-cli \
         php${PHP}-ctype \
+        php${PHP}-pecl-decimal \
         php${PHP}-dom \
         php${PHP}-fileinfo \
         php${PHP}-iconv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apk add --update --no-cache \
         docker-cli \
         php${PHP}-cli \
         php${PHP}-ctype \
-        php${PHP}-pecl-decimal \
         php${PHP}-dom \
         php${PHP}-fileinfo \
         php${PHP}-iconv \
@@ -34,6 +33,7 @@ RUN apk add --update --no-cache \
         php${PHP}-xmlreader \
         php${PHP}-xmlwriter \
         php${PHP}-zip \
+        php${PHP}-pecl-decimal \
         php${PHP}-pecl-mongodb \
         php${PHP}-pecl-pcov \
         php${PHP}-pecl-rdkafka \

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Core
 ctype
 curl
 date
+decimal
 dom
 fileinfo
 filter


### PR DESCRIPTION
## Motivação

Após o uso do `phpctl` em alguns projetos, notei a falta da extensão decimal.

## Objetivo

Instalar a extensão `decimal` do PHP no Dockerfile

## O que foi feito

- Adicionado `php${PHP}-pecl-decimal` ao Dockerfile
- Adicionado `decimal` na listagem de módulos do readme

## Nota

> Você pode conferir todas as extensões do projeto e suas versões a partir do comando abaixo executado dentro da imagem.

```shell
php -r '$all = get_loaded_extensions(); foreach($all as $i) { $ext = new ReflectionExtension($i); $ver = $ext->getVersion(); echo "$i - $ver" . PHP_EOL;}'

Core - 8.2.16
date - 8.2.16
libxml - 8.2.16
pcre - 8.2.16
zlib - 8.2.16
filter - 8.2.16
hash - 8.2.16
json - 8.2.16
random - 8.2.16
readline - 8.2.16
Reflection - 8.2.16
SPL - 8.2.16
session - 8.2.16
ctype - 8.2.16
curl - 8.2.16
dom - 20031129
fileinfo - 8.2.16
iconv - 8.2.16
mbstring - 8.2.16
openssl - 8.2.16
pcntl - 8.2.16
PDO - 8.2.16
posix - 8.2.16
standard - 8.2.16
SimpleXML - 8.2.16
sockets - 8.2.16
sodium - 8.2.16
sqlite3 - 8.2.16
tokenizer - 8.2.16
xml - 8.2.16
xmlwriter - 8.2.16
zip - 1.21.1
mysqlnd - mysqlnd 8.2.16
Phar - 8.2.16
xmlreader - 8.2.16
pdo_mysql - 8.2.16
igbinary - 3.2.15
msgpack - 2.2.0
redis - 6.0.2
swoole - 5.1.1
decimal - 1.5.0
mongodb - 1.17.2
pcov - 1.0.11
rdkafka - 6.0.3
/usr/local/src # 

```

![image](https://github.com/opencodeco/phpctl/assets/41749399/d8eb0b28-4aa1-4557-9370-66dd58850079)
