### PR TITLE
Add container runtime detection

### DIFF
--- a/bin/phpctl
+++ b/bin/phpctl
@@ -9,8 +9,20 @@ fi
 PHP_VERSION=${PHP_VERSION:-82}
 PHPCTL_IMAGE=${PHPCTL_IMAGE:-opencodeco/phpctl:php$PHP_VERSION}
 PHPCTL_TTY=${PHPCTL_TTY:--it}
-PHPCTL_RUNTIME=${PHPCTL_RUNTIME:-docker}
+PHPCTL_RUNTIME=${PHPCTL_RUNTIME:-detect}
 PHPCTL_USER=${PHPCTL_USER:-root}
+
+if [ "${PHPCTL_RUNTIME}" == "detect" ]; then
+    PHPCTL_RUNTIME=
+    if command -v docker > /dev/null 2>&1; then
+        PHPCTL_RUNTIME=docker
+    elif command -v podman > /dev/null 2>&1; then
+        PHPCTL_RUNTIME=podman
+    else
+        echo "Could not find neither \"docker\" nor \"podman\", aborting"
+        exit 1
+    fi
+fi
 
 for file in "$PHPCTL_DIR"/src/*.sh; do
     # shellcheck source=src/php.sh


### PR DESCRIPTION
This PR adds container runtime detection with support for `docker` and `podman`, it does so by using a _"special"_ value for `PHPCTL_RUNTIME` (`PHPCTL_RUNTIME=detect`) that is set by default when no `PHPCTL_RUNTIME` is set by neither `phpctlrc` nor environment variable.

This allows seamless usage for environments where `docker` is not available but `podman` is.