### PR TITLE
fix gitconfig invalid characters issue

### DIFF
--- a/src/docker.sh
+++ b/src/docker.sh
@@ -53,7 +53,7 @@ run() {
 
     local gitconfig=""
     if [ -f ~/.gitconfig ]; then
-        gitconfig="-v ~/.gitconfig:/root/.gitconfig:ro"
+        gitconfig="-v $HOME/.gitconfig:/root/.gitconfig:ro"
     fi
 
     if [ -n "$GIT_EXEC_PATH" ]; then


### PR DESCRIPTION
This PR fixes the following issue:

```BASH
phpctl php -v

docker: Error response from daemon: create ~/.gitconfig: "~/.gitconfig" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

### Operating System
```BASH
uname -a

Linux desktop 6.5.0-26-generic #26~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Mar 12 10:22:43 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
```

```BASH
lsb_release -a

No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04.4 LTS
Release:	22.04
Codename:	jammy
```



### Docker version
```
docker --version
Docker version 26.0.0, build 2ae903e
```