### PR TITLE
Improve install/uninstall scripts for non-root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.sh]
+charset = utf-8
+trim_trailing_whitespace = true
+indent_size = 4
+indent_style = space

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Take the advantage of goodies commands like `phpctl create` to start a new proje
 ### Installation
 
 ```shell
-/bin/bash -c "$(curl -fsSL https://phpctl.dev/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/opencodeco/phpctl/refs/heads/main/docs/install.sh)"
 ```
 
 **That is it!** Now you have `phpctl` available in your system.
@@ -26,7 +26,7 @@ Take the advantage of goodies commands like `phpctl create` to start a new proje
 #### Custom installation
 You can also pass an argument to install at a custom location (e.g. `~/bin`), but you have to make sure that folder is in your `$PATH` variable.
 ```shell
-/bin/bash -c "$(curl -fsSL https://phpctl.dev/install.sh)" ~/bin
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/opencodeco/phpctl/refs/heads/main/docs/install.sh)" -s ~/bin
 ```
 
 #### Homebrew

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,46 +1,125 @@
 #!/usr/bin/env bash
 
-INSTALL_DIR=~/.phpctl
-if [ -z "$1" ]; then
-    SUDO=sudo
-    SYMLINK_DIR=/usr/local/bin
-else
-    SUDO=""
+INSTALL_DIR="${HOME}/.phpctl"
+SYMLINK_DIR="/usr/local/bin"
+LOCAL_SOURCES_DIR=""
+
+# --- Option Parsing ---
+while getopts "hi:s:l:" opt; do
+    case $opt in
+    h)
+        echo "Install phpctl sources and creates symlinks for easy usage."
+        echo ""
+        echo "Usage: $0 [OPTIONS]"
+        echo "Options:"
+        echo "  -h                Display this help message and exit"
+        echo "  -i <directory>    Set the installation directory (default: $HOME/.phpctl)"
+        echo "  -s <directory>    Set the symlink directory (default: /usr/local/bin)"
+        echo "  -l <directory>    Set the local sources directory. If empty, will fetch sources from github. (default: empty string)"
+        exit 0
+        ;;
+    i)
+        INSTALL_DIR="$OPTARG"
+        ;;
+    s)
+        SYMLINK_DIR="$OPTARG"
+        ;;
+    l)
+        LOCAL_SOURCES_DIR="$OPTARG"
+        ;;
+    \?)
+        echo "Error: Invalid option: -$OPTARG" >&2
+        echo "Try '$0 -h' for more information." >&2
+        exit 1
+        ;;
+    :)
+        echo "Error: Option -$OPTARG requires an argument." >&2
+        echo "Try '$0 -h' for more information." >&2
+        exit 1
+        ;;
+    esac
+done
+
+# Shift off the options and their arguments, so that any remaining
+# positional parameters (if any) are correctly handled.
+shift $((OPTIND - 1))
+
+# Compatibility with previous script version
+if [[ $SYMLINK_DIR = "/usr/local/bin" && -n ${1} ]]; then
     SYMLINK_DIR=$1
 fi
 
-echo -e "\033[0;33mInstalling phpctl at \033[0m$INSTALL_DIR"
-if [ -d "$INSTALL_DIR" ]; then
-    echo "The install directory is not empty. Attempting to remove it..."
-    rm -rf $INSTALL_DIR
-fi
-
-echo -n ""
-git clone --quiet https://github.com/opencodeco/phpctl.git $INSTALL_DIR &
-PID=$!
-while kill -0 $PID 2> /dev/null; do
-    for CHAR in '-' '/' '|' '\'; do
-        printf "\b$CHAR"
-        sleep 0.1
-    done
-done
-printf "\r"
-
-
-if [ -z "$1" ]; then
-    echo -n "Sudo will be prompted to symlink the phpctl files."
+if [ ! -w "${SYMLINK_DIR}" ]; then
+    ELEVATED=true
 else
-    echo -n "Files will be symlinked to ${SYMLINK_DIR}."
+    ELEVATED=false
 fi
-echo -e -n " \033[0;32mDo you want to continue? (Y/n)\033[0m "
+
+if "$ELEVATED"; then
+    echo "Running in elevated mode. This might require sudo for operations in ${SYMLINK_DIR}."
+fi
+
+[[ $ELEVATED = true ]] && SUDO="sudo" || SUDO=""
+
+# Initialize colors (if available)
+if tput setaf 1 &>/dev/null; then
+    RED=$(tput setaf 1)
+    GREEN=$(tput setaf 2)
+    YELLOW=$(tput setaf 3)
+    BLUE=$(tput setaf 4)
+    NC=$(tput sgr0) # Reset attributes
+else
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m' # No Color
+fi
+
+install_sources() {
+    echo -e "${YELLOW}Installing phpctl at ${NC}$INSTALL_DIR"
+    if [ -d "$INSTALL_DIR" ]; then
+        echo "The install directory is not empty. Attempting to remove it..."
+        rm -rf "$INSTALL_DIR"
+    fi
+
+    if [[ -n "$LOCAL_SOURCES_DIR" ]]; then
+        echo "Using local sources from: $LOCAL_SOURCES_DIR"
+        cp -r "$LOCAL_SOURCES_DIR" "$INSTALL_DIR"
+    else
+        GITHUB_REPO="https://github.com/opencodeco/phpctl.git"
+        echo "Cloning from $GITHUB_REPO..."
+        echo -n ""
+        git clone --quiet "$GITHUB_REPO" "$INSTALL_DIR" &
+        PID=$!
+        while kill -0 $PID 2>/dev/null; do
+            for CHAR in '-' '/' '|' "\\"; do
+                printf "\b%s" "$CHAR"
+                sleep 0.1
+            done
+        done
+        printf "\r"
+        echo " done."
+    fi
+    echo "${GREEN}Success: ${NC}Operation completed successfully."
+}
+
+install_sources
+
+echo -n "Files will be symlinked to ${SYMLINK_DIR}."
+if [[ -n $SUDO ]]; then
+    echo -n "Sudo will be prompted to symlink the phpctl files."
+fi
+
+echo -e -n " ${GREEN}Do you want to continue? (Y/n)${NC} "
 read -r answer
 if [ "$answer" != "${answer#[Nn]}" ]; then
-    echo -e "\033[0;31mTo use phpctl globally, link the cloned script to your bin directory, like:\033[0m"
-    echo ""
+    echo -e "${RED}To use phpctl globally, link the cloned script to your bin directory, like:${NC}"
     for file in "${INSTALL_DIR}"/bin/*; do
         bin=$(basename "$file")
         echo "  ${SUDO} ln -sf ${INSTALL_DIR}/bin/$bin ${SYMLINK_DIR}/$bin"
     done
+    echo -e "${YELLOW}Or add ${INSTALL_DIR}/bin to your PATH."
 else
-    $SUDO ${INSTALL_DIR}/scripts/symlink-bins.sh ${INSTALL_DIR}
+    $SUDO "${INSTALL_DIR}/scripts/symlink-bins.sh" "${INSTALL_DIR}" "${SYMLINK_DIR}"
 fi

--- a/scripts/symlink-bins.sh
+++ b/scripts/symlink-bins.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+local_bin_path="${2:-/usr/local/bin}"
+# Add a trailing slash if it's missing
+local_bin_path="${local_bin_path%/}/"
+
 for file in "${1:-.}"/bin/*; do
-    ln -sf "$(realpath "$file")" "/usr/local/bin/$(basename "$file")"
+    ln -sf "$(realpath "$file")" "${local_bin_path}$(basename "$file")"
 done


### PR DESCRIPTION
I've changed the (un)install scripts so that they are a bit more robust

- You can now use options like -i and -s to explicitly set the install directory or the symlink path
- it can create symlinks without `sudo` if the current user has permission to do so on the target symlink path
- you can now install phpctl from a local repo with `-l`, mostly useful when you already cloned this repo and don't want to fetch from github
- use `tput` for terminal colors if possible
- can now uninstall without sudo


Also:
- remove the `phtpctl.dev` reference from install.md since that URL is no longer accessible (See #49)
- add an editorconfig just so my IDE/shfmt won't try to change every single whitespace indent